### PR TITLE
Update production domain in settings

### DIFF
--- a/docker/wagtail/Dockerfile
+++ b/docker/wagtail/Dockerfile
@@ -8,8 +8,7 @@ COPY ./docker/wagtail/wagtailcron /etc/cron.d/wagtailcron
 RUN apt-get update -qq \
 	&& apt-get -y install -qq cron \
 	&& chmod 0644 /etc/cron.d/wagtailcron \
-	&& crontab /etc/cron.d/wagtailcron \
-	&& touch /var/log/cron.log
+	&& crontab /etc/cron.d/wagtailcron
 
 # Set the working directory to /code/
 WORKDIR /code/

--- a/docker/wagtail/wagtailcron
+++ b/docker/wagtail/wagtailcron
@@ -1,1 +1,1 @@
-0 * * * * /code/container/publish_scheduled_pages.sh  >> /var/log/cron.log 2>&1
+0 * * * * /code/container/publish_scheduled_pages.sh  >> /code/data/cron.log 2> /code/data/cron.err

--- a/mysite/settings/production.py
+++ b/mysite/settings/production.py
@@ -10,6 +10,7 @@ ALLOWED_HOSTS = [
     'localhost',
     '127.0.0.1',
     'test.lpld.io',
+    'testcms.lpld.io',
 ]
 
 try:

--- a/server/nginx/wagtail.nginx
+++ b/server/nginx/wagtail.nginx
@@ -2,7 +2,7 @@ server {
     listen 80;
     listen [::]:80;
 
-    server_name localhost;
+    server_name localhost test.lpld.io testcms.lpld.io;
 
     server_tokens off;
     charset utf-8;


### PR DESCRIPTION
The backend server can not really live on the same domain as the frontend. It needs it's own domain. 

But, the frontend can use redirects/rewrites to forward requests to the backend to the appropriate domain. Using rewrites, the URL in the browser remains the same.