### PR TITLE
Fix BASE URL setting to make images available during headless build

### DIFF
--- a/mysite/settings/base.py
+++ b/mysite/settings/base.py
@@ -171,7 +171,11 @@ WAGTAIL_MODERATION_ENABLED = False
 
 # Base URL to use when referring to full URLs within the Wagtail admin backend -
 # e.g. in notification emails. Don't include '/admin' or a trailing slash
-BASE_URL = 'https://test.lpld.io'
+#
+# This needs to be the actual server domain, so that during the headless build
+# the images are available from the backend. If this would be the frontend domain
+# then the generated image URLs do not exist during build.
+BASE_URL = 'https://testcms.lpld.io'
 
 # Grapple settings
 GRAPHENE = {
@@ -197,4 +201,4 @@ HEADLESS_PREVIEW_CLIENT_URLS = {
 }
 
 # Headless serve
-HEADLESS_SERVE_BASE_URL = BASE_URL
+HEADLESS_SERVE_BASE_URL = 'https://test.lpld.io'

--- a/server/nginx/wagtail.nginx
+++ b/server/nginx/wagtail.nginx
@@ -32,7 +32,7 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-Protocol $scheme;
     }
-    location /cms {
+    location / {
         try_files $uri @yourapplication;
     }
     location @yourapplication {
@@ -47,9 +47,5 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-Protocol $scheme;
-    }
-
-    location / {
-        try_files $uri $uri =404;
     }
 }


### PR DESCRIPTION
The `BASE_URL` needs to be the actual backend server domain, so that during the headless build
the images are available from the backend. If this would be the frontend domain
then the generated image URLs do not exist during build.