### PR TITLE
Add `documentsExtended` query with `src` field

### DIFF
--- a/documents_extension/schema.py
+++ b/documents_extension/schema.py
@@ -9,6 +9,14 @@ import grapple
 
 
 def get_document_url(cls):
+    """
+    Create qualified URL on which a document is accessible.
+
+    Basically copied from:
+    https://github.com/GrappleGQL/wagtail-grapple/blob/
+    569b05d73282bee41b6c0509d413638b1aa9b040/grapple/types/images.py#L19
+
+    """
     url = ''
     if hasattr(cls, 'url'):
         url = cls.url

--- a/documents_extension/schema.py
+++ b/documents_extension/schema.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+
+"""Extend the `DocumentObjectType` provided by  `wagtail-grapple`."""
+
+from django.conf import settings
+import wagtail
+import graphene
+import grapple
+
+
+def get_document_url(cls):
+    url = ''
+    if hasattr(cls, 'url'):
+        url = cls.url
+    else:
+        url = cls.file.url
+
+    if url[0] == '/':
+        return settings.BASE_URL + url
+    return url
+
+
+class ExtendedDocumentObjectType(grapple.types.documents.DocumentObjectType):
+    class Meta:
+        model = wagtail.documents.get_document_model()
+        exclude_fields = ("tags",)
+
+    src = graphene.String()
+
+    def resolve_src(self, info):
+        """Get URL of the document."""
+        return get_document_url(self)
+
+
+class Query(graphene.ObjectType):
+    documents_extended = graphene.List(
+        ExtendedDocumentObjectType,
+        id_=graphene.ID(name='id'),
+    )
+
+    def resolve_documents_extended(self, info, id_=None):
+        doc_model = wagtail.documents.get_document_model()
+        if not id_:
+            return doc_model.objects.all().order_by('pk')
+        return doc_model.objects.all().filter(pk=id_)

--- a/mysite/schema.py
+++ b/mysite/schema.py
@@ -2,6 +2,7 @@ import graphene
 from grapple.schema import schema as gs
 
 from tagging.schema import Query as TaggingQuery
+from documents_extension.schema import Query as ExtendedDocumentsQuery
 
 GrappleQuery = gs.Query
 GrappleSubscription = gs.Subscription
@@ -10,6 +11,7 @@ GrappleSubscription = gs.Subscription
 class Query(
     GrappleQuery,
     TaggingQuery,
+    ExtendedDocumentsQuery,
 ):
     pass
 

--- a/mysite/settings/base.py
+++ b/mysite/settings/base.py
@@ -166,8 +166,9 @@ MEDIA_URL = '/media/'
 
 # Wagtail settings
 
-WAGTAIL_SITE_NAME = "mysite"
+WAGTAIL_SITE_NAME = 'mysite'
 WAGTAIL_MODERATION_ENABLED = False
+WAGTAILDOCS_SERVE_METHOD = 'direct'
 
 # Base URL to use when referring to full URLs within the Wagtail admin backend -
 # e.g. in notification emails. Don't include '/admin' or a trailing slash


### PR DESCRIPTION
Before, it was not possible to query the document URL directly. The URL had to be constructed on the client side. 

This was not very elegant and prone to error due to out of sync configuration between backend and client/frontend. 

The now `documentsExtended` query provides an extended document object type with a `src` filed. This filed will give the client a fully qualified URL to access the document. 